### PR TITLE
Add `app.js` to list of files that are watched for rebuild

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,7 @@ gulp.task('serve', function () {
     }
   });
 
-  gulp.watch(['scripts/*.js', '*.html'], ['watch-source']);
+  gulp.watch(['app.js', 'scripts/*.js', '*.html'], ['watch-source']);
 
 });
 


### PR DESCRIPTION
Because `app.js` was not in the watched files, several of the early steps in the tutorial which only change that file do not trigger an automatic rebuild and BrowserSync of the app.

Adding it to the watched files makes everything behave as expected.
